### PR TITLE
feat 질문페이지 질문 삭제 기능

### DIFF
--- a/src/pages/QuestionPage/index.js
+++ b/src/pages/QuestionPage/index.js
@@ -30,7 +30,22 @@ const ReactionButtonBox = ({ question }) => {
   );
 };
 
-const QuestionItem = ({ user, question }) => {
+const QuestionItem = ({ user, question, setQuestions, setQuestionCount }) => {
+  const deleteQuestion = async questionId => {
+    const response = await fetch(`${API_BASE_URL}/questions/${questionId}/`, {
+      method: 'DELETE',
+    });
+
+    if (response.ok) {
+      setQuestions(prevQuestions =>
+        prevQuestions.filter(prevQuestion => prevQuestion.id !== question.id),
+      );
+      setQuestionCount(prevCount => prevCount - 1);
+    } else if (!response.ok) {
+      throw new Error('질문 삭제 실패했습니다');
+    }
+  };
+
   return (
     <section className="question-answer-box answer-complete">
       {question.answer ? (
@@ -70,9 +85,13 @@ const QuestionItem = ({ user, question }) => {
           </div>
         </div>
       ) : null}
-      <ReactionButtonBox question={question} />
+      <ReactionButtonBox question={question} setQuestions={setQuestions} />
 
-      <button type="button" className="question-delete-button">
+      <button
+        type="button"
+        className="question-delete-button"
+        onClick={() => deleteQuestion(question.id)}
+      >
         삭제하기
       </button>
     </section>
@@ -138,6 +157,7 @@ const QuestionPage = () => {
   const [questions, setQuestions] = useState([]);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(0);
+  const [questionCount, setQuestionCount] = useState(0);
 
   const elementRef = useRef(null);
 
@@ -156,6 +176,7 @@ const QuestionPage = () => {
       setPage(prevPage => prevPage + 1);
     }
   };
+
   const onInterSection = entries => {
     const firstEntry = entries[0];
     if (firstEntry.isIntersecting && hasMore) {
@@ -177,6 +198,7 @@ const QuestionPage = () => {
   const fetchData = async () => {
     const responseUser = await getUser(id);
     setUser(responseUser);
+    setQuestionCount(responseUser.questionCount);
   };
   useEffect(() => {
     fetchData();
@@ -190,16 +212,20 @@ const QuestionPage = () => {
         <article className="question-list-container">
           <div className="title-box">
             <figure className="title-image" />
-            <span className="title">
-              {user.questionCount}개의 질문이 있습니다
-            </span>
+            <span className="title">{questionCount}개의 질문이 있습니다</span>
           </div>
           {/* 질문이 없는 경우 no-question-image 활성화
           <figure className="no-question-image" /> */}
 
           <div className="question-list">
             {questions.map(question => (
-              <QuestionItem key={question.id} user={user} question={question} />
+              <QuestionItem
+                key={question.id}
+                user={user}
+                question={question}
+                setQuestions={setQuestions}
+                setQuestionCount={setQuestionCount}
+              />
             ))}
             {hasMore && <div ref={elementRef}>Load More Questins...</div>}
           </div>

--- a/src/pages/QuestionPage/index.js
+++ b/src/pages/QuestionPage/index.js
@@ -4,7 +4,7 @@ import getElapsedTime from '../../utils/getElapsedTime';
 import QuestionPageContainer from './style';
 
 const API_BASE_URL = 'https://openmind-api.vercel.app/3-5';
-
+// PR 잘되나?
 const getUser = async userId => {
   const response = await fetch(`${API_BASE_URL}/subjects/${userId}/`);
   if (!response.ok) {

--- a/src/pages/QuestionPage/index.js
+++ b/src/pages/QuestionPage/index.js
@@ -4,7 +4,7 @@ import getElapsedTime from '../../utils/getElapsedTime';
 import QuestionPageContainer from './style';
 
 const API_BASE_URL = 'https://openmind-api.vercel.app/3-5';
-// PR 잘되나?
+
 const getUser = async userId => {
   const response = await fetch(`${API_BASE_URL}/subjects/${userId}/`);
   if (!response.ok) {
@@ -71,6 +71,10 @@ const QuestionItem = ({ user, question }) => {
         </div>
       ) : null}
       <ReactionButtonBox question={question} />
+
+      <button type="button" className="question-delete-button">
+        삭제하기
+      </button>
     </section>
   );
 };

--- a/src/pages/QuestionPage/style.js
+++ b/src/pages/QuestionPage/style.js
@@ -149,6 +149,25 @@ const QuestionPageContainer = styled.div`
       min-height: 243px;
       padding: 32px;
       margin-bottom: 20px;
+      position: relative;
+
+      .question-delete-button {
+        position: absolute;
+        top: 28px;
+        right: 32px;
+        width: 100px;
+        height: 35px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border-radius: 200px;
+        background: var(--Brown-40);
+        box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+        border: 0;
+
+        color: var(--Grayscale-10, #fff);
+        font-size: 1.5rem;
+      }
     }
 
     .answer {


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 질문 삭제 버튼 만들고 삭제 기능 구현

## 📣리뷰어에게 하고싶은 말

- 질문 수정 api가 없다는 것을 오늘 밤에 알았습니다. 그래서 질문 삭제만 구현했습니다.
- `window.location.reload(true)`는 삭제버튼을 눌렀을 때, 새로고침 되면서 스크롤이 맨위로 올라가버리는 문제가 있었습니다.
- `filter` 메서드를 이용해서 삭제되는 값을 찾아서 없애고, 클라이언트 부분에 렌더링 해주었습니다 .
- 관련링크 
- https://stackoverflow.com/questions/70948507/reactj-s-item-deleted-only-after-refresh-delete-method

## ❗관련이슈

- closed: #16 

## 🖼️스크린샷(선택)
![삭제기능구현](https://github.com/OPENMIND-TFT/OPENMIND/assets/72595163/88a2ce85-7214-4904-b5d7-dd30df78a9a4)


